### PR TITLE
Implement a batch import UI for punches

### DIFF
--- a/CRM/Timetrack/Page/Import.php
+++ b/CRM/Timetrack/Page/Import.php
@@ -1,0 +1,19 @@
+<?php
+use CRM_Timetrack_ExtensionUtil as E;
+
+class CRM_Timetrack_Page_Import extends CRM_Core_Page {
+
+
+  public function run() {
+    $loader = new \Civi\Angular\AngularLoader();
+    $loader->setModules(array('timetrackImport'));
+    $loader->setPageName('civicrm/timetrack/import');
+    $loader->useApp(array(
+      'defaultRoute' => '/import',
+    ));
+    $loader->load();
+    CRM_Utils_System::setTitle('CiviCRM');
+    parent::run();
+  }
+
+}

--- a/ang/timetrackImport.ang.php
+++ b/ang/timetrackImport.ang.php
@@ -1,0 +1,17 @@
+<?php
+// This file declares an Angular module which can be autoloaded
+// in CiviCRM. See also:
+// http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
+
+return array(
+  'js' => array(
+    'ang/timetrackImport.js',
+    'ang/timetrackImport/*.js',
+    'ang/timetrackImport/*/*.js',
+  ),
+  'css' => ['ang/timetrackImport.css'],
+  'partials' => ['ang/timetrackImport'],
+  'requires' => ['crmUi', 'crmUtil', 'ngRoute'],
+  'settings' => [],
+  'basePages' => [],
+);

--- a/ang/timetrackImport.css
+++ b/ang/timetrackImport.css
@@ -1,0 +1,1 @@
+/* Add any CSS rules for Angular module "timetrackImport" */

--- a/ang/timetrackImport.js
+++ b/ang/timetrackImport.js
@@ -1,0 +1,4 @@
+(function(angular, $, _) {
+  // Declare a list of dependencies.
+  angular.module('timetrackImport', CRM.angRequires('timetrackImport'));
+})(angular, CRM.$, CRM._);

--- a/ang/timetrackImport/ImportCtrl.html
+++ b/ang/timetrackImport/ImportCtrl.html
@@ -10,7 +10,7 @@
 
       <pre>
 <u>{{ts('Format:')}}</u>
-[!pi -s] [&lt;yyyy-mm-dd&gt;] &lt;hh:ss&gt;+&lt;duration&gt; &lt;alias/task&gt; &lt;comment&gt;
+[!pi -s] [&lt;yyyy-mm-dd&gt;] &lt;hh:mm&gt;+&lt;duration&gt; &lt;alias/task&gt; &lt;comment&gt;
 
 <u>{{ts('Examples:')}}</u>
 2019-02-03 12:34+1h alias/cat1 make the foo

--- a/ang/timetrackImport/ImportCtrl.html
+++ b/ang/timetrackImport/ImportCtrl.html
@@ -10,12 +10,17 @@
 
       <pre>
 <u>{{ts('Format:')}}</u>
-[!pi -s] [&lt;yyyy-mm-dd&gt;] &lt;hh:mm&gt;+&lt;duration&gt; &lt;alias/task&gt; &lt;comment&gt;
+[!pi -s] [&lt;yyyy-mm-dd&gt; | &lt;dow&gt; &lt;mm/dd&gt;] &lt;hh:mm&gt;+&lt;duration&gt; &lt;alias/task&gt; &lt;comment&gt;
 
 <u>{{ts('Examples:')}}</u>
-2019-02-03 12:34+1h alias/cat1 make the foo
-11:00+1.5h alias/cat2 make the foobar
-!pi -s 20:00+30m alias/cat3 make the foobarwhiz</pre>
+2019-02-03 12:30+1.5h alias/task1 make the foo
+2019-02-04 14:00+30m alias/task2 make the whiz bang
+
+Sun 2/3 12:30+1.5h alias/task1 make the foo
+Mon 2/4 14:00+30m alias/task2 make the whiz bang
+
+12:30+1.5h alias/cat1 make the foobar
+14:00+30m alias/cat2 make the whiz bang</pre>
     </div>
 
 

--- a/ang/timetrackImport/ImportCtrl.html
+++ b/ang/timetrackImport/ImportCtrl.html
@@ -1,0 +1,76 @@
+<div class="crm-container">
+  <h1 crm-page-title>{{ts('Timetrack: Personal import')}}</h1>
+
+  <div crm-ui-debug="importModel"></div>
+
+  <form name="timetrackImportForm" crm-ui-id-scope>
+
+    <div class="help">
+      <p><em>{{ts('Import a series of time-punches.')}}</em></p>
+
+      <pre>
+<u>{{ts('Format:')}}</u>
+!pi -s [&lt;yyyy-mm-dd&gt;] &lt;hh:ss&gt;+&lt;duration&gt; &lt;alias/task&gt; &lt;comment&gt;
+
+<u>{{ts('Examples:')}}</u>
+!pi -s 2019-02-03 12:34+1h alias/cat1 make the foo
+!pi -s 11:00+1.5h alias/cat2 make the foobar
+!pi -s 20:00+30m alias/cat3 make the foobarwhiz</pre>
+    </div>
+
+
+    <div crm-ui-accordion="{title: ts('Import')}">
+      <textarea ng-model="importModel.plaintext" style="width: 90%; height: 10em;"></textarea>
+    </div>
+
+    <div crm-ui-accordion="{title: ts('Errors')}" ng-show="importModel.errors.length > 0">
+      <table>
+        <thead>
+        <tr>
+          <th>{{ts('Line No')}}</th>
+          <th>{{ts('Content')}}</th>
+          <th>{{ts('Error')}}</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr ng-repeat="punch in importModel.errors">
+          <td class="error">{{punch.lineNo}}</td>
+          <td class="error">{{punch.line}}</td>
+          <td class="error">{{punch.message}}</td>
+        </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div crm-ui-accordion="{title: ts('Preview')}" ng-show="importModel.punches.length > 0">
+      <table>
+        <thead>
+        <tr>
+          <th>{{ts('Contact ID')}}</th>
+          <th>{{ts('Start Time')}}</th>
+          <th>{{ts('Duration')}}</th>
+          <th>{{ts('Task Alias')}}</th>
+          <th>{{ts('Comment')}}</th>
+        </tr>
+        </thead>
+        <tbody>
+          <tr ng-repeat="punch in importModel.punches">
+            <td>{{punch.contact_id}}</td>
+            <td>{{punch.begin}}</td>
+            <td>{{punch.duration / 60 | number:0}} min</td>
+            <td>{{punch.alias}}</td>
+            <td>{{punch.comment}}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <br/>
+
+    <div>
+      <button ng-click="submit()" ng-disabled="importModel.punches.length == 0 || importModel.errors.length > 0">{{ts('Import')}}</button>
+    </div>
+
+  </form>
+
+</div>

--- a/ang/timetrackImport/ImportCtrl.html
+++ b/ang/timetrackImport/ImportCtrl.html
@@ -10,11 +10,11 @@
 
       <pre>
 <u>{{ts('Format:')}}</u>
-!pi -s [&lt;yyyy-mm-dd&gt;] &lt;hh:ss&gt;+&lt;duration&gt; &lt;alias/task&gt; &lt;comment&gt;
+[!pi -s] [&lt;yyyy-mm-dd&gt;] &lt;hh:ss&gt;+&lt;duration&gt; &lt;alias/task&gt; &lt;comment&gt;
 
 <u>{{ts('Examples:')}}</u>
-!pi -s 2019-02-03 12:34+1h alias/cat1 make the foo
-!pi -s 11:00+1.5h alias/cat2 make the foobar
+2019-02-03 12:34+1h alias/cat1 make the foo
+11:00+1.5h alias/cat2 make the foobar
 !pi -s 20:00+30m alias/cat3 make the foobarwhiz</pre>
     </div>
 

--- a/ang/timetrackImport/ImportCtrl.html
+++ b/ang/timetrackImport/ImportCtrl.html
@@ -10,7 +10,7 @@
 
       <pre>
 <u>{{ts('Format:')}}</u>
-[!pi -s] [&lt;yyyy-mm-dd&gt; | &lt;dow&gt; &lt;mm/dd&gt;] &lt;hh:mm&gt;+&lt;duration&gt; &lt;alias/task&gt; &lt;comment&gt;
+[!pi -s] [&lt;yyyy-mm-dd&gt; | &lt;dow&gt; &lt;mm/dd&gt;] [&lt;hh:mm&gt;]+&lt;duration&gt; &lt;alias/task&gt; &lt;comment&gt;
 
 <u>{{ts('Examples:')}}</u>
 2019-02-03 12:30+1.5h alias/task1 make the foo
@@ -62,7 +62,7 @@ Mon 2/4 14:00+30m alias/task2 make the whiz bang
           <tr ng-repeat="punch in importModel.punches">
             <td>{{punch.contact_id}}</td>
             <td>{{punch.begin}}</td>
-            <td>{{punch.duration / 60 | number:0}} min</td>
+            <td>{{punch.duration / 60 / 60 | number:2}} hr</td>
             <td>{{punch.alias}}</td>
             <td>{{punch.comment}}</td>
           </tr>

--- a/ang/timetrackImport/ImportCtrl.js
+++ b/ang/timetrackImport/ImportCtrl.js
@@ -1,0 +1,68 @@
+(function(angular, $, _) {
+
+  angular.module('timetrackImport').config(function($routeProvider) {
+      $routeProvider.when('/import', {
+        controller: 'TimetrackImportImportCtrl',
+        templateUrl: '~/timetrackImport/ImportCtrl.html',
+        resolve: {}
+      });
+    }
+  );
+
+  angular.module('timetrackImport').controller('TimetrackImportImportCtrl', function($scope, crmApi, crmStatus, crmUiHelp, crmUiAlert) {
+    // The ts() and hs() functions help load strings for this module.
+    var ts = $scope.ts = CRM.ts('timetrack');
+    var hs = $scope.hs = crmUiHelp({file: 'CRM/timetrackImport/ImportCtrl'}); // See: templates/CRM/timetrackImport/ImportCtrl.hlp
+
+    function newModel() {
+      return {
+        plaintext: '',
+        punches: [],
+        errors: []
+      };
+    }
+
+    $scope.importModel = newModel();
+
+    function debounce(time, func) {
+      return _.debounce(function(){
+        var a = arguments;
+        $scope.$evalAsync(function(){
+          func.apply(a);
+        });
+      }, time);
+    }
+
+    $scope.updatePreview = debounce(100, function(){
+      crmApi('Timetrackpunchlist', 'preview', {
+        text: $scope.importModel.plaintext
+      }).then(function(apiResult){
+        console.log('rx ' + new Date(), apiResult);
+        $scope.importModel.punches = _.filter(apiResult.values, function(punch){ return !punch.error;});
+        $scope.importModel.errors = _.filter(apiResult.values, function(punch){ return !!punch.error;});
+      });
+    });
+
+    $scope.$watch('importModel.plaintext', function(plainText){
+      $scope.updatePreview();
+    });
+
+    $scope.submit = function submit() {
+      return crmStatus(
+        // Status messages. For defaults, just use "{}"
+        {start: ts('Importing...'), success: ts('Imported')},
+        // The save action. Note that crmApi() returns a promise.
+        crmApi('Timetrackpunchlist', 'import', {
+          text: $scope.importModel.plaintext
+        })
+          .then(function(apiResult){
+            $scope.lastImport = apiResult.values;
+
+            crmUiAlert({title: ts('Imported'), text: apiResult.values.length + ' record(s)', type: 'success'});
+            $scope.importModel = newModel();
+          })
+      );
+    };
+  });
+
+})(angular, CRM.$, CRM._);

--- a/api/v3/Timetrackpunchlist.php
+++ b/api/v3/Timetrackpunchlist.php
@@ -41,7 +41,7 @@ function civicrm_api3_timetrackpunchlist_preview($params) {
   $txt = preg_replace('/\s*\n+\s*/', "\n", $txt);
   $lines = explode("\n", $txt);
 
-  $piPat = '\!pi';
+  $piPat = '\!pi -s';
   $datePat = '(\d\d\d\d-\d\d-\d\d)';
   $timePat = '(\d?\d:\d\d)';
   $durPat = '(\d+\.?\d*[HhMm])';
@@ -66,20 +66,20 @@ function civicrm_api3_timetrackpunchlist_preview($params) {
     if (empty($line) || $line{0} === '#') {
       continue;
     }
-    elseif (preg_match("/^$piPat -s $datePat $timePat\\+$durPat $aliasPat $commentPat/", $line, $m)) {
+    elseif (preg_match("/^($piPat )?$datePat $timePat\\+$durPat $aliasPat $commentPat/", $line, $m)) {
       $punch = $defaults + [
-          'begin' => $m[1] . ' ' . $m[2],
+          'begin' => $m[2] . ' ' . $m[3],
+          'duration' => $m[4],
+          'alias' => $m[5],
+          'comment' => $m[6],
+        ];
+    }
+    elseif (preg_match("/^($piPat )?$timePat\\+$durPat $aliasPat $commentPat/", $line, $m)) {
+      $punch = $defaults + [
+          'begin' => CRM_Utils_Time::getTime('Y-m-d') . ' ' . $m[2],
           'duration' => $m[3],
           'alias' => $m[4],
           'comment' => $m[5],
-        ];
-    }
-    elseif (preg_match("/^$piPat -s $timePat\\+$durPat $aliasPat $commentPat/", $line, $m)) {
-      $punch = $defaults + [
-          'begin' => CRM_Utils_Time::getTime('Y-m-d') . ' ' . $m[1],
-          'duration' => $m[2],
-          'alias' => $m[3],
-          'comment' => $m[4],
         ];
     }
     else {

--- a/api/v3/Timetrackpunchlist.php
+++ b/api/v3/Timetrackpunchlist.php
@@ -47,7 +47,7 @@ function civicrm_api3_timetrackpunchlist_preview($params) {
   $ymdDatePat = '\d\d\d\d-\d\d-\d\d';
   $datePat = '(' . $ymdDatePat . '|' . $dowDatePat . ')';
   $timePat = '(\d?\d:\d\d)';
-  $durPat = '(\d+\.?\d*[HhMm])';
+  $durPat = '(\d+\.?\d*)(H|h|hr|M|m|min)';
   $aliasPat = '(\S+)';
   $commentPat = '(.*)';
 
@@ -72,17 +72,17 @@ function civicrm_api3_timetrackpunchlist_preview($params) {
     elseif (preg_match("/^($piPat )?$datePat $timePat\\+$durPat $aliasPat $commentPat/", $line, $m)) {
       $punch = $defaults + [
           'begin' => ['date' => $m[2], 'time' => $m[3]],
-          'duration' => $m[4],
-          'alias' => $m[5],
-          'comment' => $m[6],
+          'duration' => ['qty' => $m[4], 'unit' => $m[5]],
+          'alias' => $m[6],
+          'comment' => $m[7],
         ];
     }
     elseif (preg_match("/^($piPat )?$timePat\\+$durPat $aliasPat $commentPat/", $line, $m)) {
       $punch = $defaults + [
           'begin' => ['date' => CRM_Utils_Time::getTime('Y-m-d'), 'time' => $m[2]],
-          'duration' => $m[3],
-          'alias' => $m[4],
-          'comment' => $m[5],
+          'duration' => ['qty' => $m[3], 'unit' => $m[4]],
+          'alias' => $m[5],
+          'comment' => $m[6],
         ];
     }
     else {
@@ -189,18 +189,18 @@ function civicrm_api3_timetrackpunchlist_import($params) {
 }
 
 function _civicrm_api3_timetrackpunchlist_normdur($duration) {
-  $len = mb_strlen($duration);
-  $unit = $duration{$len - 1};
   $min = NULL;
-  switch ($unit) {
+  switch ($duration['unit']) {
     case 'h':
+    case 'hr':
     case 'H':
-      $min = round(60 * rtrim($duration, 'hH'));
+      $min = round(60 * $duration['qty']);
       break;
 
     case 'm':
+    case 'min':
     case 'M':
-      $min = rtrim($duration, 'mM');
+      $min = $duration['qty'];
       break;
   }
 

--- a/api/v3/Timetrackpunchlist.php
+++ b/api/v3/Timetrackpunchlist.php
@@ -70,7 +70,7 @@ function civicrm_api3_timetrackpunchlist_preview($params) {
     if (empty($line) || $line{0} === '#') {
       continue;
     }
-    elseif (preg_match("/^($piPat)? ?($datePat)? ?($timePat)?\\+($durPat)($durUnitPat) ($aliasPat) ($commentPat)$/", $line, $m)) {
+    elseif (preg_match("/^($piPat)? ?($datePat)? ?($timePat)?\\+($durPat)($durUnitPat) ($aliasPat)( ?$commentPat)?$/", $line, $m)) {
       // print_r(['l'=>$line, 'm'=>$m]);
       $punch = $defaults + [
           'begin' => [
@@ -82,7 +82,7 @@ function civicrm_api3_timetrackpunchlist_preview($params) {
             'unit' => $m[5],
           ],
           'alias' => $m[6],
-          'comment' => $m[7],
+          'comment' => ltrim($m[7]),
         ];
     }
     else {
@@ -135,6 +135,7 @@ function civicrm_api3_timetrackpunchlist_preview($params) {
       foreach (['contact_id', 'comment', 'alias', 'begin', 'duration'] as $field) {
         if (empty($punch[$field])) {
           $punch = $error_defaults + ['message' => 'Missing required field: ' . $field];
+          break;
         }
       }
     }

--- a/api/v3/Timetrackpunchlist.php
+++ b/api/v3/Timetrackpunchlist.php
@@ -39,6 +39,7 @@ function civicrm_api3_timetrackpunchlist_preview($params) {
 
   $txt = $params['text'];
   $txt = preg_replace('/\s*\n+\s*/', "\n", $txt);
+  $txt = preg_replace("/[ \t]+/", " ", $txt);
   $lines = explode("\n", $txt);
 
   $piPat = '\!pi -s';

--- a/api/v3/Timetrackpunchlist.php
+++ b/api/v3/Timetrackpunchlist.php
@@ -1,0 +1,204 @@
+<?php
+use CRM_Timetrack_ExtensionUtil as E;
+
+/**
+ * The Timetrackpunchlist API deals with a list of punches as a set.
+ * Suggested workflow:
+ *
+ * 1. Call `Timetrackpunchlist.preview text=...` to see what will be done
+ * 2. Examine the output
+ * 3. Call `Timetrackpunchlist.import text=...` to actually import the list.
+ */
+
+/**
+ * Timetrackpunchlist.preview API specification (optional)
+ *
+ * @param array $spec description of fields supported by this API call
+ * @return void
+ * @see http://wiki.civicrm.org/confluence/display/CRMDOC/API+Architecture+Standards
+ */
+function _civicrm_api3_timetrackpunchlist_preview_spec(&$spec) {
+  $spec['text']['api.required'] = 1;
+}
+
+/**
+ * Timetrackpunchlist.preview API
+ *
+ * @param array $params
+ * @return array API result descriptor
+ * @see civicrm_api3_create_success
+ * @see civicrm_api3_create_error
+ * @throws API_Exception
+ */
+function civicrm_api3_timetrackpunchlist_preview($params) {
+  if (empty($params['text'])) {
+    throw new API_Exception(/*errorMessage*/
+      'Missing required parameter: text', /*errorCode*/
+      1000);
+  }
+
+  $txt = $params['text'];
+  $txt = preg_replace('/\s*\n+\s*/', "\n", $txt);
+  $lines = explode("\n", $txt);
+
+  $piPat = '\!pi';
+  $datePat = '(\d\d\d\d-\d\d-\d\d)';
+  $timePat = '(\d?\d:\d\d)';
+  $durPat = '(\d+\.?\d*[HhMm])';
+  $aliasPat = '(\S+)';
+  $commentPat = '(.*)';
+
+  $defaults = [];
+  $defaults['contact_id'] = isset($params['contact_id'])
+    ? $params['contact_id']
+    : CRM_Core_Session::singleton()->get('userID');
+
+  $punches = [];
+  foreach ($lines as $lineNo => $line) {
+    $punch = NULL;
+
+    $error_defaults = [
+      'error' => 1,
+      'lineNo' => (1 + $lineNo),
+      'line' => $line,
+    ];
+
+    if (empty($line) || $line{0} === '#') {
+      continue;
+    }
+    elseif (preg_match("/^$piPat -s $datePat $timePat\\+$durPat $aliasPat $commentPat/", $line, $m)) {
+      $punch = $defaults + [
+          'begin' => $m[1] . ' ' . $m[2],
+          'duration' => $m[3],
+          'alias' => $m[4],
+          'comment' => $m[5],
+        ];
+    }
+    elseif (preg_match("/^$piPat -s $timePat\\+$durPat $aliasPat $commentPat/", $line, $m)) {
+      $punch = $defaults + [
+          'begin' => CRM_Utils_Time::getTime('Y-m-d') . ' ' . $m[1],
+          'duration' => $m[2],
+          'alias' => $m[3],
+          'comment' => $m[4],
+        ];
+    }
+    else {
+      $punch = $error_defaults + ['message' => 'Failed to parse line'];
+    }
+
+    if (isset($punch['duration'])) {
+      try {
+        $punch['duration'] = _civicrm_api3_timetrackpunchlist_normdur($punch['duration']);
+      }
+      catch (API_Exception $e) {
+        $punch = $error_defaults + ['message' => 'Malformed duration'];
+      }
+    }
+
+    if (isset($punch['alias'])) {
+      $alias = _civicrm_api3_timetrackpunchlist_expand_alias($punch['alias']);
+      if ($alias) {
+        $punch['alias'] = $alias;
+      }
+      else {
+        $punch = $error_defaults + ['message' => 'Unrecognized task alias (' . $punch['alias'] . ')'];
+      }
+    }
+
+    if (empty($punch['error'])) {
+      foreach (['contact_id', 'comment', 'alias', 'begin', 'duration'] as $field) {
+        if (empty($punch[$field])) {
+          $punch = $error_defaults + ['message' => 'Missing required field: ' . $field];
+        }
+      }
+    }
+
+    $punches[] = $punch;
+  }
+
+  return civicrm_api3_create_success($punches, $params, 'Timetrackpunchlist', 'preview');
+}
+
+/**
+ * Timetrackpunchlist.import API specification (optional)
+ * This is used for documentation and validation.
+ *
+ * @param array $spec description of fields supported by this API call
+ * @return void
+ * @see http://wiki.civicrm.org/confluence/display/CRMDOC/API+Architecture+Standards
+ */
+function _civicrm_api3_timetrackpunchlist_import_spec(&$spec) {
+  _civicrm_api3_timetrackpunchlist_preview_spec($spec);
+}
+
+/**
+ * Timetrackpunchlist.import API
+ *
+ * @param array $params
+ * @return array API result descriptor
+ * @see civicrm_api3_create_success
+ * @see civicrm_api3_create_error
+ * @throws API_Exception
+ */
+function civicrm_api3_timetrackpunchlist_import($params) {
+  $plannedItems = civicrm_api3_timetrackpunchlist_preview($params);
+
+  foreach ($plannedItems['values'] as $itemNum => $item) {
+    if (!empty($item['error'])) {
+      throw new \API_Exception("Cannot execute plan: error in item #" . (1 + $itemNum));
+    }
+  }
+
+  $result = [];
+  CRM_Core_Transaction::create(TRUE)
+    ->run(function () use ($plannedItems, &$result) {
+      foreach ($plannedItems['values'] as $itemNum => $item) {
+        $params = $item + ['check_permissions' => 1];
+        $create = civicrm_api3('Timetrackpunch', 'create', $params);
+        $result[$itemNum] = $create['values'];
+      }
+    });
+
+  return civicrm_api3_create_success($result, $params, 'Timetrackpunchlist', 'import');
+}
+
+function _civicrm_api3_timetrackpunchlist_normdur($duration) {
+  $len = mb_strlen($duration);
+  $unit = $duration{$len - 1};
+  $min = NULL;
+  switch ($unit) {
+    case 'h':
+    case 'H':
+      $min = round(60 * rtrim($duration, 'hH'));
+      break;
+
+    case 'm':
+    case 'M':
+      $min = rtrim($duration, 'mM');
+      break;
+  }
+
+  if (!is_numeric($min)) {
+    throw new \API_Exception("Unrecognized duration");
+  }
+  return round($min * 60);
+}
+
+function _civicrm_api3_timetrackpunchlist_expand_alias($alias) {
+  if (isset(Civi::$statics['_civicrm_api3_timetrackpunchlist_mock_regex']) && preg_match(Civi::$statics['_civicrm_api3_timetrackpunchlist_mock_regex'], $alias)) {
+    return $alias;
+  }
+
+  try {
+    $r = civicrm_api3('Timetracktask', 'get', ['alias' => $alias]);
+    if (count($r['values']) !== 1) {
+      return FALSE;
+    }
+    foreach ($r['values'] as $task) {
+      return dirname($alias) . '/' . $task['title'];
+    }
+  }
+  catch (API_Exception $e) {
+    return FALSE;
+  }
+}

--- a/api/v3/Timetrackpunchlist.php
+++ b/api/v3/Timetrackpunchlist.php
@@ -45,11 +45,12 @@ function civicrm_api3_timetrackpunchlist_preview($params) {
   $piPat = '\!pi -s';
   $dowDatePat = '[A-Z][a-z][a-z]\s+\d+\/\d+';
   $ymdDatePat = '\d\d\d\d-\d\d-\d\d';
-  $datePat = '(' . $ymdDatePat . '|' . $dowDatePat . ')';
-  $timePat = '(\d?\d:\d\d)';
-  $durPat = '(\d+\.?\d*)(H|h|hr|M|m|min)';
-  $aliasPat = '(\S+)';
-  $commentPat = '(.*)';
+  $datePat = $ymdDatePat . '|' . $dowDatePat;
+  $timePat = '\d?\d:\d\d';
+  $durPat = '\d+\.?\d*';
+  $durUnitPat = 'H|h|hr|M|m|min';
+  $aliasPat = '\S+';
+  $commentPat = '.*';
 
   $defaults = [];
   $defaults['contact_id'] = isset($params['contact_id'])
@@ -69,18 +70,19 @@ function civicrm_api3_timetrackpunchlist_preview($params) {
     if (empty($line) || $line{0} === '#') {
       continue;
     }
-    elseif (preg_match("/^($piPat )?($datePat )?($timePat)?\\+$durPat $aliasPat $commentPat/", $line, $m)) {
+    elseif (preg_match("/^($piPat)? ?($datePat)? ?($timePat)?\\+($durPat)($durUnitPat) ($aliasPat) ($commentPat)$/", $line, $m)) {
+      // print_r(['l'=>$line, 'm'=>$m]);
       $punch = $defaults + [
           'begin' => [
-            'date' => empty($m[3]) ? CRM_Utils_Time::getTime('Y-m-d') : $m[3],
-            'time' => empty($m[5]) ? '12:00' : $m[5],
+            'date' => empty($m[2]) ? CRM_Utils_Time::getTime('Y-m-d') : $m[2],
+            'time' => empty($m[3]) ? '12:00' : $m[3],
           ],
           'duration' => [
-            'qty' => $m[6],
-            'unit' => $m[7],
+            'qty' => $m[4],
+            'unit' => $m[5],
           ],
-          'alias' => $m[8],
-          'comment' => $m[9],
+          'alias' => $m[6],
+          'comment' => $m[7],
         ];
     }
     else {

--- a/api/v3/Timetrackpunchlist.php
+++ b/api/v3/Timetrackpunchlist.php
@@ -69,20 +69,18 @@ function civicrm_api3_timetrackpunchlist_preview($params) {
     if (empty($line) || $line{0} === '#') {
       continue;
     }
-    elseif (preg_match("/^($piPat )?$datePat $timePat\\+$durPat $aliasPat $commentPat/", $line, $m)) {
+    elseif (preg_match("/^($piPat )?($datePat )?($timePat)?\\+$durPat $aliasPat $commentPat/", $line, $m)) {
       $punch = $defaults + [
-          'begin' => ['date' => $m[2], 'time' => $m[3]],
-          'duration' => ['qty' => $m[4], 'unit' => $m[5]],
-          'alias' => $m[6],
-          'comment' => $m[7],
-        ];
-    }
-    elseif (preg_match("/^($piPat )?$timePat\\+$durPat $aliasPat $commentPat/", $line, $m)) {
-      $punch = $defaults + [
-          'begin' => ['date' => CRM_Utils_Time::getTime('Y-m-d'), 'time' => $m[2]],
-          'duration' => ['qty' => $m[3], 'unit' => $m[4]],
-          'alias' => $m[5],
-          'comment' => $m[6],
+          'begin' => [
+            'date' => empty($m[3]) ? CRM_Utils_Time::getTime('Y-m-d') : $m[3],
+            'time' => empty($m[5]) ? '12:00' : $m[5],
+          ],
+          'duration' => [
+            'qty' => $m[6],
+            'unit' => $m[7],
+          ],
+          'alias' => $m[8],
+          'comment' => $m[9],
         ];
     }
     else {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<phpunit backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" syntaxCheck="false" bootstrap="tests/phpunit/bootstrap.php">
+  <testsuites>
+    <testsuite name="My Test Suite">
+      <directory>./tests/phpunit</directory>
+    </testsuite>
+  </testsuites>
+  <filter>
+    <whitelist>
+      <directory suffix=".php">./</directory>
+    </whitelist>
+  </filter>
+  <listeners>
+    <listener class="Civi\Test\CiviTestListener">
+      <arguments/>
+    </listener>
+  </listeners>
+</phpunit>

--- a/templates/CRM/Timetrack/Page/Import.tpl
+++ b/templates/CRM/Timetrack/Page/Import.tpl
@@ -1,0 +1,1 @@
+{* placeholder *}

--- a/templates/CRM/timetrackImport/ImportCtrl.hlp
+++ b/templates/CRM/timetrackImport/ImportCtrl.hlp
@@ -1,0 +1,1 @@
+{* placeholder *}

--- a/tests/phpunit/api/v3/Timetrackpunchlist/triple-plain.preview.json
+++ b/tests/phpunit/api/v3/Timetrackpunchlist/triple-plain.preview.json
@@ -1,0 +1,5 @@
+[
+  {"begin": "2019-02-03 12:34", "duration": "3600", "alias": "mock/foo", "comment": "make the foo plain", "contact_id": "@user_contact_id"},
+  {"begin": "2019-02-10 11:00", "duration": "5400", "alias": "mock/bar", "comment": "make the foobar plain", "contact_id": "@user_contact_id"},
+  {"begin": "2019-02-10 20:00", "duration": "1800", "alias": "mock/whiz", "comment": "make the foobarwhiz plain", "contact_id": "@user_contact_id"}
+]

--- a/tests/phpunit/api/v3/Timetrackpunchlist/triple-plain.preview.json
+++ b/tests/phpunit/api/v3/Timetrackpunchlist/triple-plain.preview.json
@@ -1,5 +1,6 @@
 [
   {"begin": "2019-02-03 12:34", "duration": "3600", "alias": "mock/foo", "comment": "make the foo plain", "contact_id": "@user_contact_id"},
   {"begin": "2019-02-10 11:00", "duration": "5400", "alias": "mock/bar", "comment": "make the foobar plain", "contact_id": "@user_contact_id"},
-  {"begin": "2019-02-10 20:00", "duration": "1800", "alias": "mock/whiz", "comment": "make the foobarwhiz plain", "contact_id": "@user_contact_id"}
+  {"begin": "2019-02-10 20:00", "duration": "1800", "alias": "mock/whiz", "comment": "make the foobarwhiz plain", "contact_id": "@user_contact_id"},
+  {"begin": "2019-02-10 20:00", "duration": "1200", "alias": "mock/whiz", "comment": "make the foobarwhiz plain", "contact_id": "@user_contact_id"}
 ]

--- a/tests/phpunit/api/v3/Timetrackpunchlist/triple-plain.preview.json
+++ b/tests/phpunit/api/v3/Timetrackpunchlist/triple-plain.preview.json
@@ -3,5 +3,6 @@
   {"begin": "2019-02-10 11:00", "duration": "5400", "alias": "mock/bar", "comment": "make the foobar plain", "contact_id": "@user_contact_id"},
   {"begin": "2019-02-10 20:00", "duration": "1800", "alias": "mock/whiz", "comment": "make the foobarwhiz plain", "contact_id": "@user_contact_id"},
   {"begin": "2019-02-10 20:00", "duration": "1200", "alias": "mock/whiz", "comment": "make the foobarwhiz plain", "contact_id": "@user_contact_id"},
-  {"begin": "2019-02-10 21:00", "duration": "7200", "alias": "mock/long", "comment": "make the 2 hour thing", "contact_id": "@user_contact_id"}
+  {"begin": "2019-02-10 21:00", "duration": "7200", "alias": "mock/long", "comment": "make the 2 hour thing", "contact_id": "@user_contact_id"},
+  {"begin": "2019-02-03 12:00", "duration": "3600", "alias": "mock/foo", "comment": "something without a specific time", "contact_id": "@user_contact_id"}
 ]

--- a/tests/phpunit/api/v3/Timetrackpunchlist/triple-plain.preview.json
+++ b/tests/phpunit/api/v3/Timetrackpunchlist/triple-plain.preview.json
@@ -2,5 +2,6 @@
   {"begin": "2019-02-03 12:34", "duration": "3600", "alias": "mock/foo", "comment": "make the foo plain", "contact_id": "@user_contact_id"},
   {"begin": "2019-02-10 11:00", "duration": "5400", "alias": "mock/bar", "comment": "make the foobar plain", "contact_id": "@user_contact_id"},
   {"begin": "2019-02-10 20:00", "duration": "1800", "alias": "mock/whiz", "comment": "make the foobarwhiz plain", "contact_id": "@user_contact_id"},
-  {"begin": "2019-02-10 20:00", "duration": "1200", "alias": "mock/whiz", "comment": "make the foobarwhiz plain", "contact_id": "@user_contact_id"}
+  {"begin": "2019-02-10 20:00", "duration": "1200", "alias": "mock/whiz", "comment": "make the foobarwhiz plain", "contact_id": "@user_contact_id"},
+  {"begin": "2019-02-10 21:00", "duration": "7200", "alias": "mock/long", "comment": "make the 2 hour thing", "contact_id": "@user_contact_id"}
 ]

--- a/tests/phpunit/api/v3/Timetrackpunchlist/triple-plain.preview.txt
+++ b/tests/phpunit/api/v3/Timetrackpunchlist/triple-plain.preview.txt
@@ -1,3 +1,4 @@
 2019-02-03 12:34+1h mock/foo make the foo plain
 11:00+1.5h mock/bar make the foobar plain
 20:00+30m mock/whiz make the foobarwhiz plain
+20:00+20m   mock/whiz	  make the  foobarwhiz plain

--- a/tests/phpunit/api/v3/Timetrackpunchlist/triple-plain.preview.txt
+++ b/tests/phpunit/api/v3/Timetrackpunchlist/triple-plain.preview.txt
@@ -1,0 +1,3 @@
+2019-02-03 12:34+1h mock/foo make the foo plain
+11:00+1.5h mock/bar make the foobar plain
+20:00+30m mock/whiz make the foobarwhiz plain

--- a/tests/phpunit/api/v3/Timetrackpunchlist/triple-plain.preview.txt
+++ b/tests/phpunit/api/v3/Timetrackpunchlist/triple-plain.preview.txt
@@ -1,4 +1,5 @@
 2019-02-03 12:34+1h mock/foo make the foo plain
 11:00+1.5h mock/bar make the foobar plain
 20:00+30m mock/whiz make the foobarwhiz plain
-20:00+20m   mock/whiz	  make the  foobarwhiz plain
+20:00+20min   mock/whiz	  make the  foobarwhiz plain
+21:00+2hr mock/long make the 2 hour thing

--- a/tests/phpunit/api/v3/Timetrackpunchlist/triple-plain.preview.txt
+++ b/tests/phpunit/api/v3/Timetrackpunchlist/triple-plain.preview.txt
@@ -3,3 +3,4 @@
 20:00+30m mock/whiz make the foobarwhiz plain
 20:00+20min   mock/whiz	  make the  foobarwhiz plain
 21:00+2hr mock/long make the 2 hour thing
+Sun 2/3 +1h mock/foo something without a specific time

--- a/tests/phpunit/api/v3/Timetrackpunchlist/triple.preview.json
+++ b/tests/phpunit/api/v3/Timetrackpunchlist/triple.preview.json
@@ -1,0 +1,5 @@
+[
+  {"begin": "2019-02-03 12:34", "duration": "3600", "alias": "mock/foo", "comment": "make the foo", "contact_id": "@user_contact_id"},
+  {"begin": "2019-02-10 11:00", "duration": "5400", "alias": "mock/bar", "comment": "make the foobar", "contact_id": "@user_contact_id"},
+  {"begin": "2019-02-10 20:00", "duration": "1800", "alias": "mock/whiz", "comment": "make the foobarwhiz", "contact_id": "@user_contact_id"}
+]

--- a/tests/phpunit/api/v3/Timetrackpunchlist/triple.preview.txt
+++ b/tests/phpunit/api/v3/Timetrackpunchlist/triple.preview.txt
@@ -1,0 +1,3 @@
+!pi -s 2019-02-03 12:34+1h mock/foo make the foo
+!pi -s 11:00+1.5h mock/bar make the foobar
+!pi -s 20:00+30m mock/whiz make the foobarwhiz

--- a/tests/phpunit/api/v3/Timetrackpunchlist/witherror.preview.json
+++ b/tests/phpunit/api/v3/Timetrackpunchlist/witherror.preview.json
@@ -9,6 +9,7 @@
   {"error": 1, "lineNo": 9, "line": "2019-02-03 12:34+1h bad/foo make the foo", "message": "Unrecognized task alias (bad/foo)"},
   {"begin": "2019-02-10 11:00", "duration": "5400", "alias": "mock/bar", "comment": "make the foobar baz", "contact_id": "@user_contact_id"},
   {"begin": "2019-02-10 20:00", "duration": "1800", "alias": "mock/whiz", "comment": "make the foobarwhiz", "contact_id": "@user_contact_id"},
-  {"error": 1, "lineNo": 12, "line": "Sat 2/3 15:30+45m mock/whiz with invalid dow", "message": "Day-of-week does not match date"},
+  {"error": 1, "lineNo": 12, "line": "Sun 2/3 14:30+30m mock/whiz", "message": "Missing required field: comment"},
+  {"error": 1, "lineNo": 13, "line": "Sat 2/3 15:30+45m mock/whiz with invalid dow", "message": "Day-of-week does not match date"},
   {"begin": "2019-02-03 15:30", "duration": "1800", "alias": "mock/whiz", "comment": "with valid dow", "contact_id": "@user_contact_id"}
 ]

--- a/tests/phpunit/api/v3/Timetrackpunchlist/witherror.preview.json
+++ b/tests/phpunit/api/v3/Timetrackpunchlist/witherror.preview.json
@@ -8,5 +8,7 @@
   {"begin": "2019-02-03 12:34", "duration": "3600", "alias": "mock/foo", "comment": "make the foo", "contact_id": "@user_contact_id"},
   {"error": 1, "lineNo": 9, "line": "2019-02-03 12:34+1h bad/foo make the foo", "message": "Unrecognized task alias (bad/foo)"},
   {"begin": "2019-02-10 11:00", "duration": "5400", "alias": "mock/bar", "comment": "make the foobar baz", "contact_id": "@user_contact_id"},
-  {"begin": "2019-02-10 20:00", "duration": "1800", "alias": "mock/whiz", "comment": "make the foobarwhiz", "contact_id": "@user_contact_id"}
+  {"begin": "2019-02-10 20:00", "duration": "1800", "alias": "mock/whiz", "comment": "make the foobarwhiz", "contact_id": "@user_contact_id"},
+  {"error": 1, "lineNo": 12, "line": "Sat 2/3 15:30+45m mock/whiz with invalid dow", "message": "Day-of-week does not match date"},
+  {"begin": "2019-02-03 15:30", "duration": "1800", "alias": "mock/whiz", "comment": "with valid dow", "contact_id": "@user_contact_id"}
 ]

--- a/tests/phpunit/api/v3/Timetrackpunchlist/witherror.preview.json
+++ b/tests/phpunit/api/v3/Timetrackpunchlist/witherror.preview.json
@@ -1,0 +1,8 @@
+[
+  {"begin": "2019-02-03 12:34", "duration": "3600", "alias": "mock/foo", "comment": "make the foo", "contact_id": "@user_contact_id"},
+  {"error": 1, "lineNo": 2, "line": "!pi -s 2019-02-03 12:34+1h bad/foo make the foo", "message": "Unrecognized task alias (bad/foo)"},
+  {"error": 1, "lineNo": 3, "line": "!pi 2019-02-03 12:34+1h mock/foo make the foo", "message": "Failed to parse line"},
+  {"begin": "2019-02-10 11:00", "duration": "5400", "alias": "mock/bar", "comment": "make the foobar", "contact_id": "@user_contact_id"},
+  {"error": 1, "lineNo": 6, "line": "!pi 11:00+1.5h mock/bar make the foobar", "message": "Failed to parse line"},
+  {"begin": "2019-02-10 20:00", "duration": "1800", "alias": "mock/whiz", "comment": "make the foobarwhiz", "contact_id": "@user_contact_id"}
+]

--- a/tests/phpunit/api/v3/Timetrackpunchlist/witherror.preview.json
+++ b/tests/phpunit/api/v3/Timetrackpunchlist/witherror.preview.json
@@ -4,5 +4,9 @@
   {"error": 1, "lineNo": 3, "line": "!pi 2019-02-03 12:34+1h mock/foo make the foo", "message": "Failed to parse line"},
   {"begin": "2019-02-10 11:00", "duration": "5400", "alias": "mock/bar", "comment": "make the foobar", "contact_id": "@user_contact_id"},
   {"error": 1, "lineNo": 6, "line": "!pi 11:00+1.5h mock/bar make the foobar", "message": "Failed to parse line"},
+  {"begin": "2019-02-10 20:00", "duration": "1800", "alias": "mock/whiz", "comment": "make the foobarwhiz", "contact_id": "@user_contact_id"},
+  {"begin": "2019-02-03 12:34", "duration": "3600", "alias": "mock/foo", "comment": "make the foo", "contact_id": "@user_contact_id"},
+  {"error": 1, "lineNo": 9, "line": "2019-02-03 12:34+1h bad/foo make the foo", "message": "Unrecognized task alias (bad/foo)"},
+  {"begin": "2019-02-10 11:00", "duration": "5400", "alias": "mock/bar", "comment": "make the foobar baz", "contact_id": "@user_contact_id"},
   {"begin": "2019-02-10 20:00", "duration": "1800", "alias": "mock/whiz", "comment": "make the foobarwhiz", "contact_id": "@user_contact_id"}
 ]

--- a/tests/phpunit/api/v3/Timetrackpunchlist/witherror.preview.txt
+++ b/tests/phpunit/api/v3/Timetrackpunchlist/witherror.preview.txt
@@ -9,5 +9,6 @@
 2019-02-03 12:34+1h bad/foo make the foo
 11:00+1.5h mock/bar make the foobar baz
 20:00+30m mock/whiz make the foobarwhiz
+Sun 2/3 14:30+30m mock/whiz
 Sat 2/3 15:30+45m mock/whiz with invalid dow
 Sun 2/3 15:30+30m mock/whiz with valid dow

--- a/tests/phpunit/api/v3/Timetrackpunchlist/witherror.preview.txt
+++ b/tests/phpunit/api/v3/Timetrackpunchlist/witherror.preview.txt
@@ -1,0 +1,7 @@
+!pi -s 2019-02-03 12:34+1h mock/foo make the foo
+!pi -s 2019-02-03 12:34+1h bad/foo make the foo
+!pi 2019-02-03 12:34+1h mock/foo make the foo
+!pi -s 11:00+1.5h mock/bar make the foobar
+# comment
+!pi 11:00+1.5h mock/bar make the foobar
+!pi -s 20:00+30m mock/whiz make the foobarwhiz

--- a/tests/phpunit/api/v3/Timetrackpunchlist/witherror.preview.txt
+++ b/tests/phpunit/api/v3/Timetrackpunchlist/witherror.preview.txt
@@ -5,3 +5,7 @@
 # comment
 !pi 11:00+1.5h mock/bar make the foobar
 !pi -s 20:00+30m mock/whiz make the foobarwhiz
+2019-02-03 12:34+1h mock/foo make the foo
+2019-02-03 12:34+1h bad/foo make the foo
+11:00+1.5h mock/bar make the foobar baz
+20:00+30m mock/whiz make the foobarwhiz

--- a/tests/phpunit/api/v3/Timetrackpunchlist/witherror.preview.txt
+++ b/tests/phpunit/api/v3/Timetrackpunchlist/witherror.preview.txt
@@ -9,3 +9,5 @@
 2019-02-03 12:34+1h bad/foo make the foo
 11:00+1.5h mock/bar make the foobar baz
 20:00+30m mock/whiz make the foobarwhiz
+Sat 2/3 15:30+45m mock/whiz with invalid dow
+Sun 2/3 15:30+30m mock/whiz with valid dow

--- a/tests/phpunit/api/v3/TimetrackpunchlistTest.php
+++ b/tests/phpunit/api/v3/TimetrackpunchlistTest.php
@@ -1,0 +1,93 @@
+<?php
+
+use Civi\Test\HeadlessInterface;
+use Civi\Test\HookInterface;
+use Civi\Test\TransactionalInterface;
+
+/**
+ * Timetrackpunchlist.Preview API Test Case
+ * This is a generic test class implemented with PHPUnit.
+ * @group e2e
+ */
+class api_v3_TimetrackpunchlistTest extends \PHPUnit_Framework_TestCase implements \Civi\Test\EndToEndInterface {
+  use \Civi\Test\Api3TestTrait;
+
+  /**
+   * Civi\Test has many helpers, like install(), uninstall(), sql(), and sqlFile().
+   * See: https://docs.civicrm.org/dev/en/latest/testing/phpunit/#civitest
+   */
+  public function setUpHeadless() {
+    return \Civi\Test::headless()
+      ->installMe(__DIR__)
+      ->apply();
+  }
+
+  /**
+   * The setup() method is executed before the test is executed (optional).
+   */
+  public function setUp() {
+    parent::setUp();
+    CRM_Utils_Time::setTime('2019-02-10');
+    Civi::$statics['_civicrm_api3_timetrackpunchlist_mock_regex'] = ';^mock/\w+$;';
+  }
+
+  /**
+   * The tearDown() method is executed after the test was executed (optional)
+   * This can be used for cleanup.
+   */
+  public function tearDown() {
+    CRM_Utils_Time::resetTime();
+    parent::tearDown();
+  }
+
+  public function getPreviewExamples() {
+    $exs = [];
+    $glob = __DIR__ . '/Timetrackpunchlist/*.preview.txt';
+    $txtFiles = glob($glob);
+    foreach ($txtFiles as $txtFile) {
+      $jsonFile = preg_replace('/\.txt$/', '.json', $txtFile);
+      if (!file_exists($jsonFile)) {
+        throw new \RuntimeException("Found $txtFile but not $jsonFile");
+      }
+
+      $exs[basename($txtFile)] = [
+        file_get_contents($txtFile),
+        json_decode(file_get_contents($jsonFile), 1)
+      ];
+    }
+
+    return $exs;
+  }
+
+  /**
+   * @dataProvider getPreviewExamples
+   */
+  public function testPreview($textInput, $expectArray) {
+    $substitutes = ['@user_contact_id' => $this->loginAsAdmin()];
+    $expectArray = array_map(function($item) use ($substitutes) {
+      foreach (array_keys($item) as $k) {
+        $value = $item[$k];
+        if (isset($substitutes[$value])) {
+          $item[$k] = $substitutes[$value];
+        }
+      }
+      return $item;
+    }, $expectArray);
+
+    $result = civicrm_api3('Timetrackpunchlist', 'Preview', array('text' => $textInput));
+    $this->assertEquals($expectArray, $result['values']);
+  }
+
+  public function loginAsAdmin() {
+    global $_CV;
+    if (empty($_CV['ADMIN_USER'])) {
+      throw new \RuntimeException("Missing ADMIN_USER");
+    }
+    $contactID = $this->callAPISuccess('Contact', 'getvalue', ['id' => '@user:' . $_CV['ADMIN_USER'], 'return' => 'id']);
+
+    $session = CRM_Core_Session::singleton();
+    $session->set('userID', $contactID);
+    return $contactID;
+  }
+
+}

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -1,0 +1,62 @@
+<?php
+
+ini_set('memory_limit', '2G');
+ini_set('safe_mode', 0);
+eval(cv('php:boot --level=classloader', 'phpcode'));
+
+// Allow autoloading of PHPUnit helper classes in this extension.
+$loader = new \Composer\Autoload\ClassLoader();
+$loader->add('CRM_', __DIR__);
+$loader->add('Civi\\', __DIR__);
+$loader->add('api_', __DIR__);
+$loader->add('api\\', __DIR__);
+$loader->register();
+
+/**
+ * Call the "cv" command.
+ *
+ * @param string $cmd
+ *   The rest of the command to send.
+ * @param string $decode
+ *   Ex: 'json' or 'phpcode'.
+ * @return string
+ *   Response output (if the command executed normally).
+ * @throws \RuntimeException
+ *   If the command terminates abnormally.
+ */
+function cv($cmd, $decode = 'json') {
+  $cmd = 'cv ' . $cmd;
+  $descriptorSpec = array(0 => array("pipe", "r"), 1 => array("pipe", "w"), 2 => STDERR);
+  $oldOutput = getenv('CV_OUTPUT');
+  putenv("CV_OUTPUT=json");
+
+  // Execute `cv` in the original folder. This is a work-around for
+  // phpunit/codeception, which seem to manipulate PWD.
+  $cmd = sprintf('cd %s; %s', escapeshellarg(getenv('PWD')), $cmd);
+
+  $process = proc_open($cmd, $descriptorSpec, $pipes, __DIR__);
+  putenv("CV_OUTPUT=$oldOutput");
+  fclose($pipes[0]);
+  $result = stream_get_contents($pipes[1]);
+  fclose($pipes[1]);
+  if (proc_close($process) !== 0) {
+    throw new RuntimeException("Command failed ($cmd):\n$result");
+  }
+  switch ($decode) {
+    case 'raw':
+      return $result;
+
+    case 'phpcode':
+      // If the last output is /*PHPCODE*/, then we managed to complete execution.
+      if (substr(trim($result), 0, 12) !== "/*BEGINPHP*/" || substr(trim($result), -10) !== "/*ENDPHP*/") {
+        throw new \RuntimeException("Command failed ($cmd):\n$result");
+      }
+      return $result;
+
+    case 'json':
+      return json_decode($result, 1);
+
+    default:
+      throw new RuntimeException("Bad decoder format ($decode)");
+  }
+}

--- a/timetrack.civix.php
+++ b/timetrack.civix.php
@@ -263,16 +263,17 @@ function _timetrack_civix_find_files($dir, $pattern) {
  */
 function _timetrack_civix_civicrm_managed(&$entities) {
   $mgdFiles = _timetrack_civix_find_files(__DIR__, '*.mgd.php');
+  sort($mgdFiles);
   foreach ($mgdFiles as $file) {
     $es = include $file;
     foreach ($es as $e) {
       if (empty($e['module'])) {
         $e['module'] = E::LONG_NAME;
       }
-      $entities[] = $e;
       if (empty($e['params']['version'])) {
         $e['params']['version'] = '3';
       }
+      $entities[] = $e;
     }
   }
 }

--- a/timetrack.php
+++ b/timetrack.php
@@ -100,6 +100,20 @@ function timetrack_civicrm_caseTypes(&$caseTypes) {
 }
 
 /**
+ * Implements hook_civicrm_angularModules().
+ *
+ * Generate a list of Angular modules.
+ *
+ * Note: This hook only runs in CiviCRM 4.5+. It may
+ * use features only available in v4.6+.
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_caseTypes
+ */
+function timetrack_civicrm_angularModules(&$angularModules) {
+  _timetrack_civix_civicrm_angularModules($angularModules);
+}
+
+/**
  * Implementation of hook_civicrm_alterSettingsFolders
  *
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_alterSettingsFolders

--- a/xml/Menu/timetrack.xml
+++ b/xml/Menu/timetrack.xml
@@ -49,4 +49,10 @@
     <title>Gitlab</title>
     <access_callback>1</access_callback>
   </item>
+  <item>
+    <path>civicrm/timetrack/import</path>
+    <page_callback>CRM_Timetrack_Page_Import</page_callback>
+    <title>Import</title>
+    <access_arguments>access CiviCRM</access_arguments>
+  </item>
 </menu>


### PR DESCRIPTION
This defines a screen `civicrm/timetrack/import` with a big textarea. It accepts a variant of the `!pi -s` notation and displays a preview of the errors and normalized data as you edit.

![screen shot 2019-02-27 at 12 46 47 am](https://user-images.githubusercontent.com/1336047/53477306-422fa680-3a29-11e9-86b0-62bb18adb1b1.png)
