### PR TITLE
Change contact field to entityRef on punch custom search

### DIFF
--- a/CRM/Timetrack/Form/Search/TimetrackPunches.php
+++ b/CRM/Timetrack/Form/Search/TimetrackPunches.php
@@ -81,9 +81,6 @@ class CRM_Timetrack_Form_Search_TimetrackPunches extends CRM_Contact_Form_Search
 
     $elements = [];
 
-    // @todo: convert users field to EntityRef; requires https://github.com/civicrm/civicrm-core/pull/13230
-    $users = CRM_Timetrack_Utils::getUsers();
-
     $case_title = CRM_Timetrack_Utils::getCaseSubject($this->case_id);
     $this->setTitle(ts('List of punches for %1', [1 => $case_title]));
 
@@ -97,8 +94,8 @@ class CRM_Timetrack_Form_Search_TimetrackPunches extends CRM_Contact_Form_Search
     $tasks = CRM_Timetrack_Utils::getActivitiesForCase($this->case_id);
     $tasks[''] = ts('- select -');
 
-    $form->add('select', 'ktask', ts('Task'), $tasks);
-    $form->add('select', 'contact_id', ts('Contact'), $users, FALSE, ['class' => 'crm-select2']);
+    $form->add('select', 'ktask', ts('Task'), $tasks, FALSE, ['class' => 'huge crm-select2']);
+    $form->addEntityRef('contact_id', ts('Contact'), ['multiple' => TRUE, 'api' => ['params' => ['uf_user' => 1]]]);
     $form->add('text', 'comment', ts('Comment'), FALSE);
     $form->add('select', 'state', ts('Invoice status'), array_merge(array('' => ts('- select -')), CRM_Timetrack_PseudoConstant::getInvoiceStatuses()));
 
@@ -239,8 +236,8 @@ class CRM_Timetrack_Form_Search_TimetrackPunches extends CRM_Contact_Form_Search
       $clauses[] = 'kpunch.ktask_id = ' . CRM_Utils_Type::escape($this->_formValues['ktask'], 'Positive');
     }
 
-    if (! empty($this->_formValues['contact_id'])) {
-      $clauses[] = 'kpunch.contact_id = ' . CRM_Utils_Type::escape($this->_formValues['contact_id'], 'Positive');
+    if (!empty($this->_formValues['contact_id'])) {
+      $clauses[] = 'kpunch.contact_id IN (' . CRM_Utils_Type::validate($this->_formValues['contact_id'], 'CommaSeparatedIntegers') . ')';
     }
 
     if (! empty($this->_formValues['case_id'])) {

--- a/CRM/Timetrack/Utils.php
+++ b/CRM/Timetrack/Utils.php
@@ -97,26 +97,6 @@ class CRM_Timetrack_Utils {
   }
 
   /**
-   * Returns a list of contacts who have CMS access.
-   * Should probably return contacts from a certain subtype/group/permission..?
-   */
-  static function getUsers() {
-    $users = array('' => ts('- select -'));
-
-    $sql = 'SELECT c.id, c.display_name
-              FROM civicrm_uf_match uf
-        INNER JOIN civicrm_contact c ON (uf.contact_id = c.id)';
-
-    $dao = CRM_Core_DAO::executeQuery($sql);
-
-    while ($dao->fetch()) {
-      $users[$dao->id] = $dao->display_name;
-    }
-
-    return $users;
-  }
-
-  /**
    * Returns case status IDs that equal to 'open'.
    */
   static function getCaseOpenStatuses() {

--- a/info.xml
+++ b/info.xml
@@ -12,8 +12,7 @@
   <version>1.0</version>
   <develStage>alpha</develStage>
   <compatibility>
-    <ver>4.6</ver>
-    <ver>4.7</ver>
+    <ver>5.9</ver>
   </compatibility>
   <comments>See the README.md file for more information.</comments>
   <urls>


### PR DESCRIPTION
On civicrm.org clicking the "Contact" dropdown on the punch search form would cause the page to freeze for several seconds. I thought Chrome had crashed but, no the select field just had way way way too much data in it for javascript to keep up with.

This fixes the problem and also makes it a multiselect just to be nice. Note this bumps the minimum core ver required because (as the fixme stated) it depends on https://github.com/civicrm/civicrm-core/pull/13230.